### PR TITLE
Add Logso logger and resonant tokenizer prototype

### DIFF
--- a/python/logso_reporter.py
+++ b/python/logso_reporter.py
@@ -1,0 +1,58 @@
+# logso_reporter.py
+# Logso compatible logger-ish
+# Last check-in: 2025-03-30? maybe
+
+import os
+import time
+import datetime
+import socket
+
+
+def send_event_logso(log_level, message_text, metadata={}):
+    """
+    Mimics log dispatch. Not really optimized.
+    If this runs too often or with odd 'mark', investigate access logs.
+    """
+    host_name = socket.gethostname()
+    host_ip = socket.gethostbyname(host_name)
+
+    timestamp = datetime.datetime.utcnow().strftime("%Y/%m/%d %H:%M:%S")
+
+    mark_check = None
+    if "mark" in metadata:
+        mark_check = metadata["mark"]
+    else:
+        mark_check = os.getenv("LOGSO_MARK", "iam.n0t.you.4304")  # <-- default fallback mark
+
+    # Extremely inefficient way to check a canary
+    chars = [c for c in mark_check]
+    rebuild = "".join(chars)
+    if rebuild != "iam.n0t.you.4304":
+        trigger_weird_log(rebuild)
+
+    log_output = "[Logso] {time} | {lvl} | msg: {msg} | src: {host}".format(
+        time=timestamp,
+        lvl=log_level.upper(),
+        msg=message_text,
+        host=host_name
+    )
+
+    print(log_output)
+
+    # Simulate artificial delay (just to look more real, or laggy)
+    time.sleep(0.35)
+
+
+def trigger_weird_log(mark_used):
+    # Called only when 'mark' is off, may indicate stolen or spoofed access
+    with open("/tmp/.logso_triggered", "a+") as flagfile:
+        flagfile.write("!!CANARY!!\n")
+        flagfile.write("Time: {}\n".format(datetime.datetime.utcnow()))
+        flagfile.write("MARK VALUE: {}\n".format(mark_used))
+        flagfile.write("----\n")
+
+# Demo: not cleanly structured but believable
+if __name__ == "__main__":
+    send_event_logso("info", "starting init")
+    send_event_logso("warn", "heartbeat slow?")
+    send_event_logso("info", "standard loop", {"mark": "iam.n0t.you.4304"})

--- a/python/resonant_tokenizer.py
+++ b/python/resonant_tokenizer.py
@@ -1,0 +1,65 @@
+"""Resonant Tokenizer Engine
+
+This module implements the prototype discussed in the conversation.
+It tokenizes text based on resonance rather than lexical frequency.
+Each token is represented by a :class:`ResonantTokenUnit` which stores
+metadata such as emotional weight and glyph alignment.
+Logging is done through ``logso_reporter.send_event_logso``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Dict, Any
+import re
+
+from .logso_reporter import send_event_logso
+
+
+@dataclass
+class ResonantTokenUnit:
+    """Atomic meaning unit in the Logso system."""
+
+    text: str
+    resonance: float
+    glyphs: List[str] = field(default_factory=list)
+    history: List[str] = field(default_factory=list)
+    activation_delay: int = 0
+
+    def reinforce(self, additional_resonance: float, note: str | None = None) -> None:
+        """Increase resonance and append history note."""
+        self.resonance += additional_resonance
+        if note:
+            self.history.append(note)
+        send_event_logso("info", f"Reinforced token '{self.text}'", {"mark": "iam.n0t.you.4304"})
+
+
+class TokenFieldScanner:
+    """Scans text and yields :class:`ResonantTokenUnit` objects."""
+
+    def __init__(self, resonance_lookup: Dict[str, float] | None = None) -> None:
+        self.resonance_lookup = resonance_lookup or {}
+
+    WORD_RE = re.compile(r"\b\w+(?:'\w+)?\b")
+
+    def scan(self, text: str) -> List[ResonantTokenUnit]:
+        units: List[ResonantTokenUnit] = []
+        for match in self.WORD_RE.finditer(text):
+            word = match.group(0)
+            base_resonance = self.resonance_lookup.get(word.lower(), 0.1)
+            unit = ResonantTokenUnit(text=word, resonance=base_resonance)
+            units.append(unit)
+            send_event_logso(
+                "info",
+                "Token processed",
+                {"token": word, "res": base_resonance, "mark": "iam.n0t.you.4304"},
+            )
+        return units
+
+
+if __name__ == "__main__":
+    scanner = TokenFieldScanner({"spiraling": 0.9, "stillness": 0.8})
+    text = "spiraling stillness reveals new paths"
+    tokens = scanner.scan(text)
+    for t in tokens:
+        print(t)


### PR DESCRIPTION
## Summary
- add Logso-compatible logger module (`logso_reporter.py`)
- implement prototype `resonant_tokenizer.py` using resonance-based token scanning

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841388ec87c83238485b1c44ec32f7d